### PR TITLE
feat:  Adding discord listener capabilities

### DIFF
--- a/humbler.py
+++ b/humbler.py
@@ -1,15 +1,16 @@
 #!/usr/bin/env python3
-import os
-import re
-import json
-import random
 import asyncio
-import aiofiles
+import json
+import os
+import random
+import re
 import sqlite3
-from aiohttp import ClientSession
-from dotenv import load_dotenv
+
+import aiofiles
 import discord
+from aiohttp import ClientSession
 from discord.ext import commands
+from dotenv import load_dotenv
 
 load_dotenv()
 

--- a/humbler.py
+++ b/humbler.py
@@ -187,23 +187,23 @@ async def main():
 async def get_death_count(username):
     with sqlite3.connect(db_file_path) as conn:
         cursor = conn.cursor()
-        cursor.execute("SELECT death_count FROM deaths WHERE username = ?", (username,))
+        cursor.execute("SELECT season_6 FROM deaths WHERE username = ?", (username,))
         result = cursor.fetchone()
         return result[0] if result else 0
 
 async def get_scoreboard():
     with sqlite3.connect(db_file_path) as conn:
         cursor = conn.cursor()
-        cursor.execute("SELECT username, death_count FROM deaths ORDER BY death_count DESC")
+        cursor.execute("SELECT username, season_6 FROM deaths ORDER BY season_6 DESC")
         return cursor.fetchall()
 
 async def death_command(ctx, player_name):
     death_count = await get_death_count(player_name)
-    await ctx.send(f"{player_name} has died {death_count} times")
+    await ctx.send(f"{player_name} has died {death_count} times in Season 6")
 
 async def scoreboard_command(ctx):
     scoreboard = await get_scoreboard()
-    response = "Scoreboard:\n"
+    response = "Season 6 Scoreboard:\n"
     for i, (username, deaths) in enumerate(scoreboard, 1):
         response += f"{i}. {username}: {deaths} deaths\n"
     await ctx.send(response)

--- a/humbler.py
+++ b/humbler.py
@@ -178,7 +178,7 @@ async def follow_log():
             print(f"Error: {e}")
             await asyncio.sleep(1)
 
-async def main():
+async def log_processor():
     initialize_database()
     async for line in follow_log():
         if line.strip():
@@ -252,11 +252,14 @@ async def init_discord_bot():
         
     await bot.start(discord_token)
 
+async def main():
+    await asyncio.gather(
+        log_processor(),
+        init_discord_bot()
+    )
+
 if __name__ == "__main__":
     try:
-        asyncio.run(asyncio.gather(
-            main(),
-            init_discord_bot()
-        ))
+        asyncio.run(main())
     except KeyboardInterrupt:
-        print("Script terminated.")
+        print("Script terminated")

--- a/humbler.py
+++ b/humbler.py
@@ -218,7 +218,7 @@ async def init_discord_bot():
 
     intents = discord.Intents.default()
     intents.message_content = True
-    bot = commands.Bot(intents=intents)
+    bot = commands.Bot(command_prefix="?????", intents=intents)
     humbler_group = app_commands.Group(name="humbler", description="Commands for the Humbler bot")
 
     @bot.event

--- a/humbler.py
+++ b/humbler.py
@@ -233,12 +233,12 @@ async def init_discord_bot():
 
     @humbler_group.command(name="deaths", description="Check a player's death count for the current season")
     @app_commands.describe(player_name="The Minecraft username to look up")
-    async def deaths_subcommand(interaction, player_name):
+    async def deaths_subcommand(interaction: discord.Interaction, player_name: str):
         death_count = await get_death_count(player_name)
         await interaction.response.send_message(f"{player_name} has died {death_count} time(s) in Season 6")
 
     @humbler_group.command(name="scoreboard", description="Display the death scoreboard for the current season")
-    async def scoreboard_subcommand(interaction):
+    async def scoreboard_subcommand(interaction: discord.Interaction):
         scoreboard = await get_scoreboard()
         if not scoreboard:
             await interaction.response.send_message("The scoreboard is empty! No one has been humbled yet")

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ aiofiles == 23.2.1
 aiohttp == 3.9.1
 aiosignal == 1.3.1
 python-dotenv == 1.0.0
+discord.py == 2.5.2

--- a/sample.env
+++ b/sample.env
@@ -1,4 +1,5 @@
 DISCORD_WEBHOOK_URL='your_discord_webhook_url'
+DISCORD_TOKEN='your_discord_bot_token'
 JSON_DEATH_MESSAGES='/path/to/deathMessages.json'
 JSON_USER_WHITELIST='/path/to/whitelist.json'
 JSON_HUMBLED_RESPONSES='/path/to/humbledResponses.json'


### PR DESCRIPTION
Adding discord listening capabilities with a discord bot and adding `death` and `scoreboard` commands as part of the initial offering. This also opens up the ability to convert the sessions requests to native bot commands 